### PR TITLE
機能追加（共通） サイドバーの項目の一部を講師アカウントのみに表示させる

### DIFF
--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -23,7 +23,7 @@
                 <p><a href="{{ route('top.show') }}">トップ</a></p>
                 <p><a href="/logout">ログアウト</a></p>
                 <p><a href="{{ route('calendar.general.show',['user_id' => Auth::id()]) }}">スクール予約</a></p>
-                @if(auth()->user()->role !='4')
+                @if(auth()->user()->role !==4)
                 <p><a href="{{ route('calendar.admin.show',['user_id' => Auth::id()]) }}">スクール予約確認</a></p>
                 <p><a href="{{ route('calendar.admin.setting',['user_id' => Auth::id()]) }}">スクール枠登録</a></p>
                 @endif

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -23,8 +23,10 @@
                 <p><a href="{{ route('top.show') }}">トップ</a></p>
                 <p><a href="/logout">ログアウト</a></p>
                 <p><a href="{{ route('calendar.general.show',['user_id' => Auth::id()]) }}">スクール予約</a></p>
+                @if(auth()->user()->role !='4')
                 <p><a href="{{ route('calendar.admin.show',['user_id' => Auth::id()]) }}">スクール予約確認</a></p>
                 <p><a href="{{ route('calendar.admin.setting',['user_id' => Auth::id()]) }}">スクール枠登録</a></p>
+                @endif
                 <p><a href="{{ route('post.show') }}">掲示板</a></p>
                 <p><a href="{{ route('user.show') }}">ユーザー検索</a></p>
             </div>


### PR DESCRIPTION
### サイドバーの項目の一部を講師アカウントのみに表示させる

**【おこなったこと】**

- sidebar.balde.php に「もしログインしているしている人の権限が4(生徒)でなかったら」という条件分岐の記述を追加。

**【解説】**

- もし～ならばなのでif文となることが想像できる。
- そして比較演算としてログインユーザーなのでauth()->user()、そして権限が4の人なのでrore=4となる。
- 比較する対象は権限が4でないか否かなので、!==4となる。

**【その他】**
今回の除外は単純に表示するだけで良いため
`@if(auth()->user->rore !==4)`
となる。またmiddleweraでルートも制限がかかっているため、bladeのみで問題ない。
==は値と型どちらもチェックしてくれるため!==がよい。

closed #6 